### PR TITLE
Not avoiding the possibility of -∞ value in UCI::pv

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1678,9 +1678,6 @@ string UCI::pv(const Position& pos, Depth depth) {
       Depth d = updated ? depth : std::max(1, depth - 1);
       Value v = updated ? rootMoves[i].uciScore : rootMoves[i].previousScore;
 
-      if (v == -VALUE_INFINITE)
-          v = VALUE_ZERO;
-
       if (ss.rdbuf()->in_avail()) // Not at first line
           ss << "\n";
 


### PR DESCRIPTION
The **-∞** value only occurs when there is a bug in the search function or the evaluation function, so changing it to **zero** value is completely wrong, and this will prevent from Solving the bugs.