### PR TITLE
Add avx512f only support

### DIFF
--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -32,6 +32,8 @@ set_arch_x86_64() {
     true_arch='x86-64-vnni256'
   elif check_flags 'avx512f' 'avx512bw'; then
     true_arch='x86-64-avx512'
+  elif check_flags 'avx512f'; then
+    true_arch='x86-64-avx512f'
   elif [ -z "${znver_1_2+1}" ] && check_flags 'bmi2'; then
     true_arch='x86-64-bmi2'
   elif check_flags 'avx2'; then

--- a/src/Makefile
+++ b/src/Makefile
@@ -97,6 +97,7 @@ VPATH = external:nnue:nnue/features
 # sse41 = yes/no      --- -msse4.1           --- Use Intel Streaming SIMD Extensions 4.1
 # avx2 = yes/no       --- -mavx2             --- Use Intel Advanced Vector Extensions 2
 # avxvnni = yes/no    --- -mavxvnni          --- Use Intel Vector Neural Network Instructions AVX
+# avx512f = yes/no    --- -mavx512f          --- Use Intel Advanced Vector Extensions 512 Foundation Only
 # avx512 = yes/no     --- -mavx512bw         --- Use Intel Advanced Vector Extensions 512
 # vnni256 = yes/no    --- -mavx256vnni       --- Use Intel Vector Neural Network Instructions 512 with 256bit operands
 # vnni512 = yes/no    --- -mavx512vnni       --- Use Intel Vector Neural Network Instructions 512
@@ -124,7 +125,7 @@ endif
 # explicitly check for the list of supported architectures (as listed with make help),
 # the user can override with `make ARCH=x86-32-vnni256 SUPPORTED_ARCH=true`
 ifeq ($(ARCH), $(filter $(ARCH), \
-                 x86-64-vnni512 x86-64-vnni256 x86-64-avx512 x86-64-avxvnni x86-64-bmi2 \
+                 x86-64-vnni512 x86-64-vnni256 x86-64-avx512 x86-64-avx512f x86-64-avxvnni x86-64-bmi2 \
                  x86-64-avx2 x86-64-sse41-popcnt x86-64-modern x86-64-ssse3 x86-64-sse3-popcnt \
                  x86-64 x86-32-sse41-popcnt x86-32-sse2 x86-32 ppc-64 ppc-32 e2k \
                  armv7 armv7-neon armv8 armv8-dotprod apple-silicon general-64 general-32 riscv64 loongarch64))
@@ -147,6 +148,7 @@ ssse3 = no
 sse41 = no
 avx2 = no
 avxvnni = no
+avx512f = no
 avx512 = no
 vnni256 = no
 vnni512 = no
@@ -248,7 +250,7 @@ ifeq ($(findstring -bmi2,$(ARCH)),-bmi2)
 	pext = yes
 endif
 
-ifeq ($(findstring -avx512,$(ARCH)),-avx512)
+ifeq ($(findstring -avx512f,$(ARCH)),-avx512f)
 	popcnt = yes
 	sse = yes
 	sse2 = yes
@@ -256,7 +258,18 @@ ifeq ($(findstring -avx512,$(ARCH)),-avx512)
 	sse41 = yes
 	avx2 = yes
 	pext = yes
-	avx512 = yes
+	avx512f = yes
+else
+	ifeq ($(findstring -avx512,$(ARCH)),-avx512)
+		popcnt = yes
+		sse = yes
+		sse2 = yes
+		ssse3 = yes
+		sse41 = yes
+		avx2 = yes
+		pext = yes
+		avx512 = yes
+	endif
 endif
 
 ifeq ($(findstring -vnni256,$(ARCH)),-vnni256)
@@ -656,10 +669,17 @@ ifeq ($(avxvnni),yes)
 	endif
 endif
 
-ifeq ($(avx512),yes)
-	CXXFLAGS += -DUSE_AVX512
+ifeq ($(avx512f),yes)
+	CXXFLAGS += -DUSE_AVX512F
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
-		CXXFLAGS += -mavx512f -mavx512bw
+		CXXFLAGS += -mavx512f
+	endif
+else
+	ifeq ($(avx512),yes)
+		CXXFLAGS += -DUSE_AVX512
+		ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
+			CXXFLAGS += -mavx512f -mavx512bw
+		endif
 	endif
 endif
 
@@ -811,6 +831,7 @@ help:
 	@echo "x86-64-vnni512          > x86 64-bit with vnni 512bit support"
 	@echo "x86-64-vnni256          > x86 64-bit with vnni 512bit support, limit operands to 256bit wide"
 	@echo "x86-64-avx512           > x86 64-bit with avx512 support"
+	@echo "x86-64-avx512f          > x86 64-bit with avx512f only support"
 	@echo "x86-64-avxvnni          > x86 64-bit with vnni 256bit support"
 	@echo "x86-64-bmi2             > x86 64-bit with bmi2 support"
 	@echo "x86-64-avx2             > x86 64-bit with avx2 support"
@@ -949,6 +970,7 @@ config-sanity: net
 	@echo "sse41: '$(sse41)'"
 	@echo "avx2: '$(avx2)'"
 	@echo "avxvnni: '$(avxvnni)'"
+	@echo "avx512f: '$(avx512f)'"
 	@echo "avx512: '$(avx512)'"
 	@echo "vnni256: '$(vnni256)'"
 	@echo "vnni512: '$(vnni512)'"
@@ -980,6 +1002,7 @@ config-sanity: net
 	@test "$(ssse3)" = "yes" || test "$(ssse3)" = "no"
 	@test "$(sse41)" = "yes" || test "$(sse41)" = "no"
 	@test "$(avx2)" = "yes" || test "$(avx2)" = "no"
+	@test "$(avx512f)" = "yes" || test "$(avx512f)" = "no"
 	@test "$(avx512)" = "yes" || test "$(avx512)" = "no"
 	@test "$(vnni256)" = "yes" || test "$(vnni256)" = "no"
 	@test "$(vnni512)" = "yes" || test "$(vnni512)" = "no"

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -270,7 +270,9 @@ std::string compiler_info() {
 #if defined(USE_VNNI)
     compiler += " VNNI";
 #endif
-#if defined(USE_AVX512)
+#if defined(USE_AVX512F)
+    compiler += " AVX512F";
+#elif defined(USE_AVX512)
     compiler += " AVX512";
 #endif
     compiler += (HasPext ? " BMI2" : "");

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -195,7 +195,7 @@ class AffineTransform {
         if constexpr (OutputDimensions > 1)
         {
 
-    #if defined(USE_AVX512)
+    #if defined(USE_AVX512) || defined(USE_AVX512F)
             using vec_t = __m512i;
         #define vec_setzero _mm512_setzero_si512
         #define vec_set_32 _mm512_set1_epi32

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -55,7 +55,7 @@ alignas(CacheLineSize) static inline const
 template<const IndexType InputDimensions>
 void find_nnz(const std::int32_t* input, std::uint16_t* out, IndexType& count_out) {
     #if defined(USE_SSSE3)
-        #if defined(USE_AVX512)
+        #if defined(USE_AVX512) || defined(USE_AVX512F)
     using vec_t = __m512i;
             #define vec_nnz(a) _mm512_cmpgt_epi32_mask(a, _mm512_setzero_si512())
         #elif defined(USE_AVX2)
@@ -201,7 +201,7 @@ class AffineTransformSparseInput {
     void propagate(const InputType* input, OutputType* output) const {
 
 #if (USE_SSSE3 | (USE_NEON >= 8))
-    #if defined(USE_AVX512)
+    #if defined(USE_AVX512) || defined(USE_AVX512F)
         using invec_t  = __m512i;
         using outvec_t = __m512i;
         #define vec_set_32 _mm512_set1_epi32

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -49,7 +49,61 @@ using PSQTWeightType = std::int32_t;
 static_assert(PSQTBuckets % 8 == 0,
               "Per feature PSQT values cannot be processed at granularity lower than 8 at a time.");
 
-#ifdef USE_AVX512
+#ifdef USE_AVX512F
+using vec_t      = __m512i;
+using psqt_vec_t = __m256i;
+    #define vec_load(a) _mm512_load_si512(a)
+    #define vec_store(a, b) _mm512_store_si512(a, b)
+    #define vec_add_16(a, b) __builtin_shufflevector(                                                               \
+            _mm256_add_epi16(__builtin_shufflevector(a, a, 0, 1, 2, 3), __builtin_shufflevector(b, b, 0, 1, 2, 3)), \
+            _mm256_add_epi16(__builtin_shufflevector(a, a, 4, 5, 6, 7), __builtin_shufflevector(b, b, 4, 5, 6, 7)), \
+            0, 1, 2, 3, 4, 5, 6, 7                                                                                  \
+        )
+    #define vec_sub_16(a, b) __builtin_shufflevector(                                                               \
+            _mm256_sub_epi16(__builtin_shufflevector(a, a, 0, 1, 2, 3), __builtin_shufflevector(b, b, 0, 1, 2, 3)), \
+            _mm256_sub_epi16(__builtin_shufflevector(a, a, 4, 5, 6, 7), __builtin_shufflevector(b, b, 4, 5, 6, 7)), \
+            0, 1, 2, 3, 4, 5, 6, 7                                                                                  \
+        )
+    #define vec_mul_16(a, b) __builtin_shufflevector(                                                                 \
+            _mm256_mullo_epi16(__builtin_shufflevector(a, a, 0, 1, 2, 3), __builtin_shufflevector(b, b, 0, 1, 2, 3)), \
+            _mm256_mullo_epi16(__builtin_shufflevector(a, a, 4, 5, 6, 7), __builtin_shufflevector(b, b, 4, 5, 6, 7)), \
+            0, 1, 2, 3, 4, 5, 6, 7                                                                                    \
+        )
+    #define vec_zero() _mm512_setzero_epi32()
+    #define vec_set_16(a) _mm512_set1_epi16(a)
+    #define vec_max_16(a, b) __builtin_shufflevector(                                                               \
+            _mm256_max_epi16(__builtin_shufflevector(a, a, 0, 1, 2, 3), __builtin_shufflevector(b, b, 0, 1, 2, 3)), \
+            _mm256_max_epi16(__builtin_shufflevector(a, a, 4, 5, 6, 7), __builtin_shufflevector(b, b, 4, 5, 6, 7)), \
+            0, 1, 2, 3, 4, 5, 6, 7                                                                                  \
+        )
+    #define vec_min_16(a, b) __builtin_shufflevector(                                                               \
+            _mm256_min_epi16(__builtin_shufflevector(a, a, 0, 1, 2, 3), __builtin_shufflevector(b, b, 0, 1, 2, 3)), \
+            _mm256_min_epi16(__builtin_shufflevector(a, a, 4, 5, 6, 7), __builtin_shufflevector(b, b, 4, 5, 6, 7)), \
+            0, 1, 2, 3, 4, 5, 6, 7                                                                                  \
+        )
+inline vec_t vec_msb_pack_16(vec_t a, vec_t b) {
+    vec_t compacted = __builtin_shufflevector(
+        _mm256_packs_epi16(
+            _mm256_srli_epi16(__builtin_shufflevector(a, a, 0, 1, 2, 3), 7),
+            _mm256_srli_epi16(__builtin_shufflevector(b, b, 0, 1, 2, 3), 7)
+        ),
+        _mm256_packs_epi16(
+            _mm256_srli_epi16(__builtin_shufflevector(a, a, 4, 5, 6, 7), 7),
+            _mm256_srli_epi16(__builtin_shufflevector(b, b, 4, 5, 6, 7), 7)
+        ),
+        0, 1, 2, 3, 4, 5, 6, 7
+    );
+    return _mm512_permutexvar_epi64(_mm512_setr_epi64(0, 2, 4, 6, 1, 3, 5, 7), compacted);
+}
+    #define vec_load_psqt(a) _mm256_load_si256(a)
+    #define vec_store_psqt(a, b) _mm256_store_si256(a, b)
+    #define vec_add_psqt_32(a, b) _mm256_add_epi32(a, b)
+    #define vec_sub_psqt_32(a, b) _mm256_sub_epi32(a, b)
+    #define vec_zero_psqt() _mm256_setzero_si256()
+    #define NumRegistersSIMD 16
+    #define MaxChunkSize 64
+
+#elif USE_AVX512
 using vec_t      = __m512i;
 using psqt_vec_t = __m256i;
     #define vec_load(a) _mm512_load_si512(a)


### PR DESCRIPTION
The CPU with only AVX512F but no AVX512BW can also use partial AVX512 acceleration.
Tested on Phi-7230 CPU, it is about 10% faster than AVX2.