### PR TITLE
Add M1 mac build

### DIFF
--- a/.github/workflows/pikafish.yml
+++ b/.github/workflows/pikafish.yml
@@ -94,9 +94,9 @@ jobs:
 
       # Artifacts automatically get zipped.
       # To avoid double-zipping, we use the unzipped directory
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:	
-          name: Pikafish
+          name: Pikafish-${{ matrix.config.name }}${{ matrix.arch }}
           path: |
             ${{ matrix.config.name }}/*
             Wiki
@@ -156,9 +156,9 @@ jobs:
 
       # Artifacts automatically get zipped.
       # To avoid double-zipping, we use the unzipped directory
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:	
-          name: Pikafish	
+          name: Pikafish-Android-${{ matrix.arch }}
           path: |
             Android/*
             AUTHORS

--- a/.github/workflows/pikafish.yml
+++ b/.github/workflows/pikafish.yml
@@ -79,12 +79,7 @@ jobs:
           wget -q https://github.com/official-pikafish/Networks/releases/download/master-net/pikafish.nnue
           make -j profile-build EXE=$EXE WINE_PATH="$SDE"
           make strip EXE=$EXE
-
-      - name: Copy binary to folder
-        run: |
-          cd ..
-          mkdir ${{ matrix.config.name }}
-          cp src/$EXE ${{ matrix.config.name }}
+          cp $EXE ../
 
       - name: Download wiki
         run: |
@@ -98,7 +93,50 @@ jobs:
         with:	
           name: Pikafish-${{ matrix.config.name }}${{ matrix.arch }}
           path: |
-            ${{ matrix.config.name }}/*
+            ${{ env.EXE }}
+            Wiki
+            AUTHORS
+            CONTRIBUTING.md
+            Copying.txt
+            README.md
+            Top CPU Contributors.txt
+
+  Pikafish-MacOS-M1:
+    name: MacOS-apple-silicon
+    runs-on: macos-14
+    env:
+      ARCH: apple-silicon
+      COMPILER: clang++
+      COMP: clang
+      EXE: pikafish-apple-silicon
+    defaults:
+      run:
+        working-directory: src
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compile apple-silicon build
+        run: |
+          wget -q https://github.com/official-pikafish/Networks/releases/download/master-net/pikafish.nnue
+          make -j profile-build EXE=$EXE
+          make strip EXE=$EXE
+          cp $EXE ../
+
+      - name: Download wiki
+        run: |
+          git clone https://github.com/official-pikafish/Pikafish.wiki.git ../Wiki
+          cd ../Wiki
+          rm -rf .git
+
+      # Artifacts automatically get zipped.
+      # To avoid double-zipping, we use the unzipped directory
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Pikafish-MacOS-M1-apple-silicon
+          path: |
+            ${{ env.EXE }}
             Wiki
             AUTHORS
             CONTRIBUTING.md
@@ -147,12 +185,7 @@ jobs:
           wget -q https://github.com/official-pikafish/Networks/releases/download/master-net/pikafish.nnue
           make -j profile-build EXE=$EXE WINE_PATH=$EMU
           make strip EXE=$EXE
-
-      - name: Copy binary to folder
-        run: |
-          cd ..
-          mkdir Android
-          cp src/$EXE Android
+          cp $EXE ../
 
       # Artifacts automatically get zipped.
       # To avoid double-zipping, we use the unzipped directory
@@ -160,5 +193,9 @@ jobs:
         with:	
           name: Pikafish-Android-${{ matrix.arch }}
           path: |
-            Android/*
+            ${{ env.EXE }}
             AUTHORS
+            CONTRIBUTING.md
+            Copying.txt
+            README.md
+            Top CPU Contributors.txt

--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ the Stockfish developers (https://github.com/official-stockfish/Stockfish/blob/m
 陶然 (pickaxe919)
 wxc
 张大仙 (fengxs001)
+Xusheng


### PR DESCRIPTION
This PR does two things:

1. It updates the action to use upload-artifacts@v4, which can properly archive the build artifacts. 
2. It adds a new job that builds Pikafish on the newly available M1 runners. I first tried to integrate that into the matrix, but the exclude rules soon becomes very inflated, and I figured it would be better to create a separate job for the M1 build