### PR TITLE
feat: Enable AVX-512 4VNNIW for Intel Knights Mill

### DIFF
--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -195,6 +195,7 @@ set_arch_x86_64() {
 	true_arch=$(
 		select_arch_from_table <<'EOF'
 # Strongest -> weakest (first match wins)
+x86-64-knm|match_flags|avx512f avx512pf avx512er avx512cd avx512vpopcntdq avx5124vnniw
 x86-64-avx512icl|match_flags|avx512f avx512cd avx512vl avx512dq avx512bw avx512ifma avx512vbmi avx512vbmi2 avx512vpopcntdq avx512bitalg avx512vnni vpclmulqdq gfni vaes
 x86-64-vnni512|match_flags|avx512vnni avx512dq avx512f avx512bw avx512vl
 x86-64-avx512|match_flags|avx512f avx512bw

--- a/src/Makefile
+++ b/src/Makefile
@@ -104,6 +104,7 @@ VPATH = $(shell find . -type d | tr '\n' ':')
 # avx512 = yes/no     --- -mavx512f          --- Use Intel Advanced Vector Extensions 512
 # vnni512 = yes/no    --- -mavx512vnni       --- Use Intel Vector Neural Network Instructions 512
 # avx512icl = yes/no  --- ... multiple ...   --- Use All AVX-512 features available on both Intel Ice Lake and AMD Zen 4
+# knm = yes/no        --- ... multiple ...   --- Use All AVX-512 features and Vector Neural Network Instructions available on Intel Knights Mill
 # altivec = yes/no    --- -maltivec          --- Use PowerPC Altivec SIMD extension
 # vsx = yes/no        --- -mvsx              --- Use POWER VSX SIMD extension
 # neon = yes/no       --- -DUSE_NEON         --- Use ARM SIMD architecture
@@ -132,7 +133,7 @@ endif
 # explicitly check for the list of supported architectures (as listed with make help),
 # the user can override with `make ARCH=x86-64-avx512icl SUPPORTED_ARCH=true`
 ifeq ($(ARCH), $(filter $(ARCH), \
-                 x86-64-avx512icl x86-64-vnni512 x86-64-avx512 x86-64-avxvnni \
+                 x86-64-knm x86-64-avx512icl x86-64-vnni512 x86-64-avx512 x86-64-avxvnni \
                  x86-64-bmi2 x86-64-avx2 x86-64-sse41-popcnt x86-64-modern x86-64-ssse3 x86-64-sse3-popcnt \
                  x86-64 x86-32-sse41-popcnt x86-32-sse2 x86-32 ppc-64 ppc-64-altivec ppc-64-vsx ppc-32 e2k \
                  armv7 armv7-neon armv8 armv8-dotprod apple-silicon general-64 general-32 riscv64 \
@@ -159,6 +160,7 @@ avxvnni = no
 avx512 = no
 vnni512 = no
 avx512icl = no
+knm = no
 altivec = no
 vsx = no
 neon = no
@@ -295,6 +297,17 @@ ifeq ($(findstring -avx512icl,$(ARCH)),-avx512icl)
 	avx512 = yes
 	vnni512 = yes
 	avx512icl = yes
+endif
+
+ifeq ($(findstring -knm,$(ARCH)),-knm)
+	popcnt = yes
+	sse = yes
+	sse2 = yes
+	ssse3 = yes
+	sse41 = yes
+	avx2 = yes
+	pext = yes
+	knm = yes
 endif
 
 ifeq ($(sse),yes)
@@ -747,6 +760,13 @@ ifeq ($(avx512icl),yes)
 	endif
 endif
 
+ifeq ($(knm),yes)
+	CXXFLAGS += -DUSE_KNM
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
+		CXXFLAGS += -mavx512f -mavx512pf -mavx512er -mavx512cd -mavx512vpopcntdq -mavx5124vnniw
+	endif
+endif
+
 ifeq ($(sse41),yes)
 	CXXFLAGS += -DUSE_SSE41
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
@@ -934,6 +954,7 @@ help:
 	echo "Supported archs:" && \
 	echo "" && \
 	echo "native                  > select the best architecture for the host processor (default)" && \
+	echo "x86-64-knm              > x86 64-bit with avx512 4vnniw support of Intel Knights Mill" && \
 	echo "x86-64-avx512icl        > x86 64-bit with minimum avx512 support of Intel Ice Lake or AMD Zen 4" && \
 	echo "x86-64-vnni512          > x86 64-bit with vnni 512bit support" && \
 	echo "x86-64-avx512           > x86 64-bit with avx512 support" && \
@@ -1083,6 +1104,7 @@ config-sanity: net
 	echo "avx512: '$(avx512)'" && \
 	echo "vnni512: '$(vnni512)'" && \
 	echo "avx512icl: '$(avx512icl)'" && \
+	echo "knm: '$(knm)'" && \
 	echo "altivec: '$(altivec)'" && \
 	echo "vsx: '$(vsx)'" && \
 	echo "neon: '$(neon)'" && \
@@ -1119,6 +1141,7 @@ config-sanity: net
 	(test "$(avx512)" = "yes" || test "$(avx512)" = "no") && \
 	(test "$(vnni512)" = "yes" || test "$(vnni512)" = "no") && \
 	(test "$(avx512icl)" = "yes" || test "$(avx512icl)" = "no") && \
+	(test "$(knm)" = "yes" || test "$(knm)" = "no") && \
 	(test "$(altivec)" = "yes" || test "$(altivec)" = "no") && \
 	(test "$(vsx)" = "yes" || test "$(vsx)" = "no") && \
 	(test "$(neon)" = "yes" || test "$(neon)" = "no") && \

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -238,6 +238,10 @@ std::string compiler_info() {
 
     compiler += "\nCompilation settings       : ";
     compiler += (Is64Bit ? "64bit" : "32bit");
+#if defined(USE_KNM)
+    compiler += " AVX512";
+    compiler += " 4VNNIW";
+#endif
 #if defined(USE_AVX512ICL)
     compiler += " AVX512ICL";
 #endif

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -78,15 +78,36 @@ alignas(CacheLineSize) static constexpr struct OffsetIndices {
         #define RESTRICT
     #endif
 
-// Find indices of nonzero 32-bit values in a packed byte buffer.
-// The input pointer addresses a sequence of 32-bit blocks stored in a
-// std::uint8_t array.
+// Find indices of nonzero 32-bit(for KNM is 64-bit) values in a packed byte buffer.
+// The input pointer addresses a sequence of 32-bit(for KNM is 64-bit) blocks stored
+// in a std::uint8_t array.
 template<const IndexType InputDimensions>
 void find_nnz(const std::uint8_t* RESTRICT input,
               std::uint16_t* RESTRICT      out,
               IndexType&                   count_out) {
 
-    #if defined(USE_AVX512ICL)
+    #if defined(USE_KNM)
+
+    constexpr IndexType SimdWidth = 8;  // 512 bits / 64 bits
+    constexpr IndexType NumChunks = InputDimensions / SimdWidth;
+    const __m512i       increment = _mm512_set1_epi64(SimdWidth);
+    __m512i base = _mm512_set_epi64(7, 6, 5, 4, 3, 2, 1, 0);
+
+    IndexType count = 0;
+    for (IndexType i = 0; i < NumChunks; ++i)
+    {
+        const __m512i inputV = _mm512_load_si512(input + i * SimdWidth * sizeof(std::uint64_t));
+
+        // Get a bitmask and gather non zero indices
+        const __mmask8 nnzMask = _mm512_test_epi64_mask(inputV, inputV);
+        const __m512i  nnzV    = _mm512_maskz_compress_epi64(nnzMask, base);
+        _mm512_mask_cvtepi64_storeu_epi16(out + count, 0xFF, nnzV);
+        count += popcount(nnzMask);
+        base = _mm512_add_epi64(base, increment);
+    }
+    count_out = count;
+
+    #elif defined(USE_AVX512ICL)
 
     constexpr IndexType SimdWidthIn  = 64;  // 512 bits
     constexpr IndexType SimdWidthOut = 32;  // 512 bits / 16 bits
@@ -215,6 +236,57 @@ class AffineTransformSparseInput {
              + i / PaddedInputDimensions * ChunkSize + i % ChunkSize;
     }
 
+    // Scrambled index mapping for the weight layout optimized for 4VNNIW SIMD instructions.
+    //
+    // The weight matrix (originally OutputDimensions x PaddedInputDimensions) is reorganized
+    // to group inputs in pairs of 8 units and outputs in blocks of 16 neurons.
+    // For each 8‑unit input pair and each 16‑neuron output group, the weights for the 16×8 = 128
+    // connections are stored in four consecutive chunks, each chunk corresponding to a 2‑unit
+    // sub‑group within the input pair (units 0‑1, 2‑3, 4‑5, 6‑7).
+    //
+    // Within a chunk, the weights for the 16 neurons are interleaved per neuron:
+    //   [neuron0_unit0, neuron0_unit1, neuron1_unit0, neuron1_unit1, ...,
+    //    neuron15_unit0, neuron15_unit1]
+    //
+    // Thus the overall memory order is:
+    //   for each input pair p (0..PaddedInputDimensions/8 - 1)
+    //     for each output group g (0..OutputDimensions/16 - 1)
+    //       for each 2‑unit sub‑group s (0..3)
+    //         for each neuron n in group g (0..15)
+    //           for each unit offset b within the sub‑group (0..1)
+    //             weight of output neuron (g*16 + n) for input unit (p*8 + s*2 + b)
+    //
+    // The mapping from the linear index i = out * InUnits + unit (where InUnits = PaddedInputDimensions)
+    // to the new linear index is:
+    //   pair   = unit / 8
+    //   sg     = (unit % 8) / 2          // sub‑group within the 8‑unit pair
+    //   sub    = (unit % 8) % 2          // offset inside the 2‑unit sub‑group
+    //   out_g  = out / 16                // output group
+    //   n      = out % 16                // neuron inside the group
+    //   new_idx = (pair * OutputDimensions * 8) + (out_g * 128) + (sg * 32) + (n * 2) + sub
+    //
+    // This layout is designed to feed 4VNNIW instructions that process 16 neurons × 8 inputs
+    // in a single operation.
+    static constexpr IndexType get_weight_index_scrambled_4vnniw(IndexType i) {
+        constexpr IndexType InBytes = PaddedInputDimensions;
+
+        const IndexType out = i / InBytes;
+        const IndexType byte = i % InBytes;
+
+        const IndexType pair = byte >> 3;          // byte / 8
+        const IndexType g = (byte >> 1) & 3;       // (byte/2) % 4
+        const IndexType sub = byte & 1;            // byte % 2
+
+        const IndexType out_group = out >> 4;      // out / 16
+        const IndexType n = out & 0xF;             // out % 16
+
+        return (pair * OutputDimensions << 3)      // pair * OutputDimensions * 8
+             + (out_group << 7)                    // out_group * 128
+             + (g << 5)                            // g * 32
+             + (n << 1)                            // n * 2
+             + sub;
+    }
+
     static constexpr IndexType get_weight_index(IndexType i) {
 #if (USE_SSSE3 | (USE_NEON >= 8))
         return get_weight_index_scrambled(i);
@@ -227,7 +299,11 @@ class AffineTransformSparseInput {
     bool read_parameters(std::istream& stream) {
         read_little_endian<BiasType>(stream, biases, OutputDimensions);
         for (IndexType i = 0; i < OutputDimensions * PaddedInputDimensions; ++i)
+#if defined(USE_KNM)
+            weights[get_weight_index_scrambled_4vnniw(i)] = static_cast<std::int16_t>(read_little_endian<WeightType>(stream));
+#else
             weights[get_weight_index(i)] = read_little_endian<WeightType>(stream);
+#endif
 
         return !stream.fail();
     }
@@ -237,7 +313,11 @@ class AffineTransformSparseInput {
         write_little_endian<BiasType>(stream, biases, OutputDimensions);
 
         for (IndexType i = 0; i < OutputDimensions * PaddedInputDimensions; ++i)
+#if defined(USE_KNM)
+            write_little_endian<WeightType>(stream, static_cast<WeightType>(weights[get_weight_index_scrambled_4vnniw(i)]));
+#else
             write_little_endian<WeightType>(stream, weights[get_weight_index(i)]);
+#endif
 
         return !stream.fail();
     }
@@ -245,7 +325,14 @@ class AffineTransformSparseInput {
     std::size_t get_content_hash() const {
         std::size_t h = 0;
         hash_combine(h, get_raw_data_hash(biases));
+#if defined(USE_KNM)
+        WeightType originalWeights[OutputDimensions * PaddedInputDimensions];
+        for (IndexType i = 0; i < OutputDimensions * PaddedInputDimensions; ++i)
+            originalWeights[i] = static_cast<WeightType>(weights[get_weight_index_scrambled_4vnniw(get_weight_index(i))]);
+        hash_combine(h, get_raw_data_hash(originalWeights));
+#else
         hash_combine(h, get_raw_data_hash(weights));
+#endif
         hash_combine(h, get_hash_value(0));
         return h;
     }
@@ -254,7 +341,7 @@ class AffineTransformSparseInput {
     void propagate(const InputType* input, OutputType* output) const {
 
 #if (USE_SSSE3 | (USE_NEON >= 8))
-    #if defined(USE_AVX512)
+    #if defined(USE_AVX512) || defined(USE_KNM)
         using invec_t  = __m512i;
         using outvec_t = __m512i;
         #define vec_add_32 _mm512_add_epi32
@@ -283,12 +370,17 @@ class AffineTransformSparseInput {
         #define vec_add_dpbusd_32 SIMD::neon_m128_add_dpbusd_epi32
     #endif
         constexpr IndexType OutputSimdWidth = sizeof(outvec_t) / sizeof(OutputType);
-        constexpr IndexType NumChunks = ceil_to_multiple<IndexType>(InputDimensions, 8) / ChunkSize;
+        constexpr IndexType NumChunks =
+    #if defined(USE_KNM)
+          ceil_to_multiple<IndexType>(InputDimensions, 8) / 8;
+    #else
+          ceil_to_multiple<IndexType>(InputDimensions, 8) / ChunkSize;
+    #endif
         constexpr IndexType NumAccums = OutputDimensions / OutputSimdWidth;
         // If we're using high-latency dot product instructions, split the accumulators
         // to create 3 separate dependency chains and merge at the end
         constexpr IndexType NumRegs =
-    #if defined(USE_VNNI)
+    #if defined(USE_VNNI) || defined(USE_KNM)
           3 * NumAccums;
     #else
           NumAccums;
@@ -296,7 +388,7 @@ class AffineTransformSparseInput {
         std::uint16_t nnz[NumChunks];
         IndexType     count;
 
-        // Find indices of nonzero 32-bit blocks
+        // Find indices of nonzero 32-bit(for KNM is 64-bit) blocks
         find_nnz<NumChunks>(input, nnz, count);
 
         const outvec_t* biasvec = reinterpret_cast<const outvec_t*>(biases);
@@ -308,16 +400,84 @@ class AffineTransformSparseInput {
         const auto* end   = nnz + count;
 
         // convince GCC to not do weird pointer arithmetic in the following loop
+    #if defined(USE_KNM)
+        const std::int16_t* weights_cp = weights;
+    #else
         const std::int8_t* weights_cp = weights;
-    #if defined(USE_VNNI)
+    #endif
+    #if defined(USE_VNNI) || defined(USE_KNM)
         for (IndexType k = NumAccums; k < NumRegs; ++k)
+        #if defined(USE_KNM)
+            acc[k] = _mm512_setzero_epi32();
+        #else
             acc[k] = vec_zero();
+        #endif
 
         while (start < end - 2)
         {
             const std::ptrdiff_t i0 = *start++;
             const std::ptrdiff_t i1 = *start++;
             const std::ptrdiff_t i2 = *start++;
+        #if defined(USE_KNM)
+            __m128i in0 =
+              _mm_cvtepu8_epi16(_mm_set1_epi64(load_as<__m64>(input + i0 * sizeof(__m64))));
+            __m128i in1 =
+              _mm_cvtepu8_epi16(_mm_set1_epi64(load_as<__m64>(input + i1 * sizeof(__m64))));
+            __m128i in2 =
+              _mm_cvtepu8_epi16(_mm_set1_epi64(load_as<__m64>(input + i2 * sizeof(__m64))));
+            const auto w0 =
+              reinterpret_cast<const invec_t*>(&weights_cp[i0 * 128 * NumAccums]);
+            const auto w1 =
+              reinterpret_cast<const invec_t*>(&weights_cp[i1 * 128 * NumAccums]);
+            const auto w2 =
+              reinterpret_cast<const invec_t*>(&weights_cp[i2 * 128 * NumAccums]);
+            for (IndexType k = 0; k < NumAccums; ++k)
+            {
+                __asm__ volatile( // Using inline assembly to avoid bugs caused by compiler optimization
+                    "vmovdqa32 %0, %%zmm8 \n\t"
+                    "vmovdqa32 %1, %%zmm9 \n\t"
+                    "vmovdqa32 %2, %%zmm10 \n\t"
+                    "vmovdqa32 %3, %%zmm0 \n\t"
+                    "vmovdqa32 %4, %%zmm1 \n\t"
+                    "vmovdqa32 %5, %%zmm2 \n\t"
+                    "vmovdqa32 %6, %%zmm3 \n\t"
+                    "vp4dpwssd %7, %%zmm0, %%zmm8 \n\t"
+                    "vmovdqa32 %8, %%zmm4 \n\t"
+                    "vmovdqa32 %9, %%zmm5 \n\t"
+                    "vmovdqa64 %%zmm8, %0 \n\t"
+                    "vmovdqa32 %10, %%zmm6 \n\t"
+                    "vmovdqa32 %11, %%zmm7 \n\t"
+                    "vp4dpwssd %12, %%zmm4, %%zmm9 \n\t"
+                    "vmovdqa32 %13, %%zmm0 \n\t"
+                    "vmovdqa32 %14, %%zmm1 \n\t"
+                    "vmovdqa64 %%zmm9, %1 \n\t"
+                    "vmovdqa32 %15, %%zmm2 \n\t"
+                    "vmovdqa32 %16, %%zmm3 \n\t"
+                    "vp4dpwssd %17, %%zmm0, %%zmm10 \n\t"
+                    "vmovdqa64 %%zmm10, %2"
+                    :
+                    "+m"(acc[k]),
+                    "+m"(acc[k + NumAccums]),
+                    "+m"(acc[k + 2 * NumAccums])
+                    :
+                    "m"(w0[k * 4 + 0]), "m"(w0[k * 4 + 1]), "m"(w0[k * 4 + 2]), "m"(w0[k * 4 + 3]), "m"(in0),
+                    "m"(w1[k * 4 + 0]), "m"(w1[k * 4 + 1]), "m"(w1[k * 4 + 2]), "m"(w1[k * 4 + 3]), "m"(in1),
+                    "m"(w2[k * 4 + 0]), "m"(w2[k * 4 + 1]), "m"(w2[k * 4 + 2]), "m"(w2[k * 4 + 3]), "m"(in2)
+                    :
+                    "zmm0", "zmm1", "zmm2", "zmm3", "zmm4",
+                    "zmm5", "zmm6", "zmm7", "zmm8", "zmm9",
+                    "zmm10"
+                );
+                /*
+                acc[k] =
+                  _mm512_4dpwssd_epi32(acc[k], w0[k * 4 + 0], w0[k * 4 + 1], w0[k * 4 + 2], w0[k * 4 + 3], &in0);
+                acc[k + NumAccums] =
+                  _mm512_4dpwssd_epi32(acc[k + NumAccums], w1[k * 4 + 0], w1[k * 4 + 1], w1[k * 4 + 2], w1[k * 4 + 3], &in1);
+                acc[k + 2 * NumAccums] =
+                  _mm512_4dpwssd_epi32(acc[k + 2 * NumAccums], w2[k * 4 + 0], w2[k * 4 + 1], w2[k * 4 + 2], w2[k * 4 + 3], &in2);
+                */
+            }
+        #else
             const invec_t        in0 =
               vec_set_32(load_as<std::int32_t>(input + i0 * sizeof(std::int32_t)));
             const invec_t in1 =
@@ -336,6 +496,7 @@ class AffineTransformSparseInput {
                 vec_add_dpbusd_32(acc[k + NumAccums], in1, col1[k]);
                 vec_add_dpbusd_32(acc[k + 2 * NumAccums], in2, col2[k]);
             }
+        #endif
         }
         for (IndexType k = 0; k < NumAccums; ++k)
             acc[k] = vec_add_32(vec_add_32(acc[k], acc[k + NumAccums]), acc[k + 2 * NumAccums]);
@@ -343,11 +504,32 @@ class AffineTransformSparseInput {
         while (start < end)
         {
             const std::ptrdiff_t i = *start++;
+        #if defined(USE_KNM)
+            __m128i in =
+              _mm_cvtepu8_epi16(_mm_set1_epi64(load_as<__m64>(input + i * sizeof(__m64))));
+            const auto w =
+              reinterpret_cast<const invec_t*>(&weights_cp[i * 128 * NumAccums]);
+            for (IndexType k = 0; k < NumAccums; ++k)
+                __asm__ volatile( // Using inline assembly to avoid bugs caused by compiler optimization
+                    "vmovdqa32 %0, %%zmm4 \n\t"
+                    "vmovdqa32 %1, %%zmm0 \n\t"
+                    "vmovdqa32 %2, %%zmm1 \n\t"
+                    "vmovdqa32 %3, %%zmm2 \n\t"
+                    "vmovdqa32 %4, %%zmm3 \n\t"
+                    "vp4dpwssd %5, %%zmm0, %%zmm4 \n\t"
+                    "vmovdqa64 %%zmm4, %0"
+                    : "+m"(acc[k])
+                    : "m"(w[k * 4 + 0]), "m"(w[k * 4 + 1]), "m"(w[k * 4 + 2]), "m"(w[k * 4 + 3]), "m"(in)
+                    : "zmm0", "zmm1", "zmm2", "zmm3", "zmm4"
+                );
+            //    acc[k] = _mm512_4dpwssd_epi32(acc[k], w[k * 4 + 0], w[k * 4 + 1], w[k * 4 + 2], w[k * 4 + 3], &in);
+        #else
             const invec_t in = vec_set_32(load_as<std::int32_t>(input + i * sizeof(std::int32_t)));
             const auto    col =
               reinterpret_cast<const invec_t*>(&weights_cp[i * OutputDimensions * ChunkSize]);
             for (IndexType k = 0; k < NumAccums; ++k)
                 vec_add_dpbusd_32(acc[k], in, col[k]);
+        #endif
         }
 
         outvec_t* outptr = reinterpret_cast<outvec_t*>(output);
@@ -371,7 +553,12 @@ class AffineTransformSparseInput {
     using WeightType = std::int8_t;
 
     alignas(CacheLineSize) BiasType biases[OutputDimensions];
+#if defined(USE_KNM)
+    // Use AVX-512_4VNNIW instructions, the type of weights must be int16.
+    alignas(CacheLineSize) std::int16_t weights[OutputDimensions * PaddedInputDimensions];
+#else
     alignas(CacheLineSize) WeightType weights[OutputDimensions * PaddedInputDimensions];
+#endif
 };
 
 }  // namespace Stockfish::Eval::NNUE::Layers


### PR DESCRIPTION
Enable specialized AVX-512 4VNNIW instructions optimized for Intel KNM architecture to improve performance on Xeon Phi platforms. Because Knights Mill does not support AVX-512BW, the generic AVX-512 code path is unavailable; BMI2 is used as the baseline for comparison.

Performance comparison on Xeon Phi-7295 (average of three runs, unit: NPS, hash: 2048, depth: 20):
| | 1 thread | 8 threads | 16 threads | 32 threads |
| --- | --- | --- | --- | --- |
| BMI2 | 63,543 | 579,345 | 1,253,591 | 2,596,264 |
| KNM | 67,860 | 613,060 | 1,305,364 | 2,784,013 |