### PR TITLE
Fix outdated comments and a typo

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Vincentzyx
 # All other authors of Pikafish (in alphabetical order)
 afkbad (xiangqishare) -> Xiangqi Rule Consultant
 Celine chen，水殿風來 -> Logo Design
+Harshycn
 杰哥教你登dua郎 (RMCQAZ)
 妙神 (iaoedsz2008)
 macteki

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -47,7 +47,7 @@ Move* generate_moves(const Position& pos, Move* moveList, Bitboard target) {
             if (Type != QUIETS)
                 b |= attacks_bb<CANNON>(from, pos.pieces()) & pos.pieces(~Us);
 
-            // Generate cannon quite moves.
+            // Generate cannon quiet moves.
             if (Type != CAPTURES)
                 b |= attacks_bb<ROOK>(from, pos.pieces()) & ~pos.pieces();
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -85,7 +85,7 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
-// does not hit the tablebase range.
+// does not hit the mate range.
 Value to_corrected_static_eval(const Value v, const int cv) {
     return std::clamp(v + cv / 131072, VALUE_MATED_IN_MAX_PLY + 1, VALUE_MATE_IN_MAX_PLY - 1);
 }
@@ -234,7 +234,6 @@ void Search::Worker::start_searching() {
     if (!uciPvSent || bestThread != this)
         main_manager()->pv(*bestThread, threads, tt, bestThread->rootDepth);
 
-    // In rare cases, pv() may change the ponder move through syzygy_extend_pv().
     std::string ponder;
     if (bestThread->rootMoves[0].pv.size() > 1)
         ponder = UCIEngine::move(bestThread->rootMoves[0].pv[1]);


### PR DESCRIPTION
Xiangqi has no Syzygy tablebases, fix two stale comments left over from
the Stockfish tablebase code:

- remove a stale comment referencing `syzygy_extend_pv()`, which does not
  exist in this codebase
- the comment about the "tablebase range" now refers to the mate range

Also fix a comment typo in movegen.cpp ("quite" -> "quiet"), and add
myself to AUTHORS as a first time contributor.

Per review feedback, the `tbhits` info output is kept since GUIs rely on
parsing it.

No functional change

Bench: 2600714