### PR TITLE
Avoid useless recapture probing in chase detection

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1153,8 +1153,8 @@ u16 Position::chased(Color c) {
                 if ((attackerType == KNIGHT || attackerType == CANNON)
                     && type_of(piece_on(to)) == ROOK)
                     chase |= (1 << idBoard[to]);
-                if ((attackerType == ADVISOR || attackerType == BISHOP)
-                    && type_of(piece_on(to)) & 1)
+                else if ((attackerType == ADVISOR || attackerType == BISHOP)
+                         && type_of(piece_on(to)) & 1)
                     chase |= (1 << idBoard[to]);
                 // Attacks against potentially unprotected pieces
                 else


### PR DESCRIPTION
In Position::chased(), the check for knight/cannon attacks against a rook was missing an `else`, so whenever such an attack was found and its chase bit already set by the first condition, the expensive "potentially unprotected pieces" fallback still executed: a futile do_move()/undo_move() pair plus a chase-legality scan over all recaptures, only to OR in the exact same chase bit again.

Turn the second condition into `else if` so the fallback only runs when neither stronger-piece rule matched, in line with the apparent intent of the comment structure. Chase detection runs inside Position::rule_judge() on the search path, so skipping the redundant work is a small speedup in repetition-heavy positions.

The result of chased() is provably unchanged: the skipped branch could only re-set an already-set bit, and its board mutations are fully reverted by undo_move().

Verified bench unchanged: 2600714

No functional change