### PR TITLE
Allow cross-compilation of Android version on Mac

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Harshycn
 妙神 (iaoedsz2008)
 macteki
 mualanhlung017
+mafanwei
 ousc (SunDaiyue)
 the Fairy-Stockfish developers (https://github.com/fairy-stockfish/Fairy-Stockfish/blob/master/AUTHORS)
 the Stockfish developers (https://github.com/official-stockfish/Stockfish/blob/master/AUTHORS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -571,12 +571,15 @@ ifeq ($(COMP),clang)
 endif
 
 ifeq ($(KERNEL),Darwin)
-	mac_target_flags := -mmacosx-version-min=10.15
-	ifneq ($(arch),any)
-		mac_target_flags += -arch $(arch)
+	# Only add macOS-specific options during non-NDK compilation
+	ifneq ($(COMP),ndk)
+		mac_target_flags := -mmacosx-version-min=10.15
+		ifneq ($(arch),any)
+			mac_target_flags += -arch $(arch)
+		endif
+		CXXFLAGS += $(mac_target_flags)
+		LDFLAGS += $(mac_target_flags)
 	endif
-	CXXFLAGS += $(mac_target_flags)
-	LDFLAGS += $(mac_target_flags)
 	XCRUN = xcrun
 endif
 
@@ -712,14 +715,16 @@ ifeq ($(optimize),yes)
 		endif
 	endif
 
-	ifeq ($(KERNEL),Darwin)
-		ifeq ($(comp),$(filter $(comp),clang icx))
-			CXXFLAGS += -mdynamic-no-pic
-		endif
-
-		ifeq ($(comp),gcc)
-			ifneq ($(arch),arm64)
+	ifneq ($(COMP),ndk)
+		ifeq ($(KERNEL),Darwin)
+			ifeq ($(comp),$(filter $(comp),clang icx))
 				CXXFLAGS += -mdynamic-no-pic
+			endif
+
+			ifeq ($(comp),gcc)
+				ifneq ($(arch),arm64)
+					CXXFLAGS += -mdynamic-no-pic
+				endif
 			endif
 		endif
 	endif


### PR DESCRIPTION
When compiling for Android (COMP=ndk) on macOS, the build fails because the
NDK's LLVM toolchain does not recognize the macOS-specific flags
`-mdynamic-no-pic` and `-mmacosx-version-min`.
﻿
This PR wraps these flags with `ifneq ($(COMP),ndk)` condition to skip them
during Android cross-compilation.

Please squash and merge this PR.